### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 VERSION = 0.2b
 PREFIX := /usr/local
 bindir = $(PREFIX)/bin
+libdir = $(PREFIX)/lib
 mandir = $(PREFIX)/share/man/man1
 INSTALL := install
+RSYNC := rsync
 
 # Replace "native" with "byte" for debug build
 BUILDTYPE=native
+
+PACKAGE_DIR=emily/$(VERSION)
 
 .PHONY: all
 all: install/bin/emily install/man/emily.1 install/lib/emily/$(VERSION)
@@ -21,7 +25,7 @@ install/man/emily.1: resources/emily.1
 	cp $< $@
 
 # Move packages in place
-install/lib/emily/$(VERSION):
+install/lib/$(PACKAGE_DIR):
 	mkdir -p $@
 
 # Use ocamlbuild to construct executable. Always run, ocamlbuild figures out freshness itself.
@@ -54,10 +58,12 @@ manpage:
 install-makedirs:
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) -d $(DESTDIR)$(mandir)
+	$(INSTALL) -d $(DESTDIR)$(libdir)/$(PACKAGE_DIR)
 
 install: install-makedirs all
 	$(INSTALL) install/bin/emily   $(DESTDIR)$(bindir)
 	$(INSTALL) install/man/emily.1 $(DESTDIR)$(mandir)
+	$(RSYNC) -r install/lib/$(PACKAGE_DIR)/ $(DESTDIR)$(libdir)/$(PACKAGE_DIR)
 
 # Clean target
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION = 0.2b
 PREFIX := /usr/local
 bindir = $(PREFIX)/bin
 mandir = $(PREFIX)/share/man/man1
+INSTALL := install
 
 # Replace "native" with "byte" for debug build
 BUILDTYPE=native
@@ -51,12 +52,12 @@ manpage:
 # Install target
 .PHONY: install install-makedirs
 install-makedirs:
-	install -d $(DESTDIR)$(bindir)
-	install -d $(DESTDIR)$(mandir)
+	$(INSTALL) -d $(DESTDIR)$(bindir)
+	$(INSTALL) -d $(DESTDIR)$(mandir)
 
 install: install-makedirs all
-	install install/bin/emily   $(DESTDIR)$(bindir)
-	install install/man/emily.1 $(DESTDIR)$(mandir)
+	$(INSTALL) install/bin/emily   $(DESTDIR)$(bindir)
+	$(INSTALL) install/man/emily.1 $(DESTDIR)$(mandir)
 
 # Clean target
 .PHONY: clean


### PR DESCRIPTION
This PR contains two changes to the makefile:
- Convert uses of `install` to use a variable that can be overridden at the commandline.
- Add a rudimentary `make install` for the packages, using rsync (though that also can be overridden at the CLI, for example to use `cp` instead of `rsync`).
